### PR TITLE
Added two attributes

### DIFF
--- a/unimpress.pl
+++ b/unimpress.pl
@@ -455,7 +455,7 @@ sub generate_slide {
     #Add slide content and refresh   
     try {
         while($content) {  #while there is still slide content left to process
-            if ($content =~ /(.*?)(>>(con|coff|B|b)\d?)/s) {    #If there is a format modifier
+            if ($content =~ /(.*?)(>>(con|coff|B|b|U|u|K|k)\d?)/s) {    #If there is a format modifier
                 $slide->addstr($1);                             #Add the part before the modifier (unprocessed)
                 my $mod = $2;                                   #Capture the actual modifier
                 $content =~ s/\Q$&\E//;                         #update content by removing our full match
@@ -470,7 +470,19 @@ sub generate_slide {
                 }
                 if ($mod =~ /b/) {                              #if bold off
                     $slide->attroff(A_BOLD);                    #turn it off
-                }                                  
+                }
+                if ($mod =~ /U/) {                              #if underline on
+                    $slide->attron(A_UNDERLINE);                #turn it on
+                }
+                if ($mod =~ /u/) {                              #if underline off
+                    $slide->attroff(A_UNDERLINE);               #turn it off
+                }
+                if ($mod =~ /K/) {                              #if blinking on
+                    $slide->attron(A_BLINK);                    #turn it on
+                }
+                if ($mod =~ /k/) {                              #if blinking off
+                    $slide->attroff(A_BLINK);                   #turn it off
+                }
             } else {                                            #if there were no modifiers
                 $slide->addstr($content);                       #just print all of it unmodified
                 $content = undef;                               #no more content


### PR DESCRIPTION
Recently gave a presentation using Unimpress, and found these attributes useful:
- A_UNDERLINE
- A_BLINK

...so I added them to unimpress.pl.

Underlining text can be done with >>U / >>u. I couldn't use >>B / >>b for blinking, since that attribute key is already used for A_BOLD. So I chose >>K / >>k.
## 

Adam
